### PR TITLE
Define dialog options object and merge with defaults

### DIFF
--- a/v2/core/ui/dialog.ts
+++ b/v2/core/ui/dialog.ts
@@ -3,17 +3,78 @@
  */
 namespace iitc.ui.dialog {
   /** Latest dialog ID? */
-  var dialog_id = 0;
+  let dialog_id: number = 0;
   /** All dialogs currently open? */
-  var dialogs = {};
+  let dialogs: Array<string> = [];
   /** Count of dialogs currently open? */
-  var dialog_count = 0;
+  let dialog_count: number = 0;
   /** The dialog with focus? */
-  var dialog_focus = null;
+  //let dialog_focus: number = 0;
 
   /**
    * Show a dialog with the given options.
    */
-  export function show(options: any): void {
+  export function show(options: DialogOptions): void {
+    let opts: ImmutableDialogOptions = initialize(options);
+    dialogs.push(opts.id);
+    dialog_count++;
+  }
+
+  export function close(): void {
+    dialog_count--;
+  }
+
+  export interface DialogOptions {
+    class?: string;
+    draggable?: boolean;
+    id?: string;
+    html?: string;
+    modal?: boolean;
+    text?: string;
+    title: string;
+    width?: number;
+  }
+
+  interface ImmutableDialogOptions extends DialogOptions {
+    readonly class: string;
+    readonly draggable: boolean;
+    readonly id: string;
+    readonly html: string;
+    readonly modal: boolean;
+    readonly text: string;
+    readonly title: string;
+    readonly width: number;
+  }
+
+  function initialize(options: DialogOptions): ImmutableDialogOptions {
+    // all optional properties must have a default
+    let defaults: DialogOptions = {
+      class: 'ui-dialog-modal',
+      draggable: true,
+      id: '',
+      html: '',
+      modal: /*iitc.isMobile*/ false,
+      text: '',
+      title: '',
+      width: 500
+    }
+
+    // hijack id
+    options.id = 'dialog-' + (options.modal ? 'modal' : (options.id ? options.id : 'anon-' + dialog_id++));
+
+    // ensure either html or text is provided
+    if (typeof options.html === 'undefined') {
+      if (typeof options.text === 'undefined') {
+        console.error('iitc.ui.dialog.show: no text in dialog ' + options.id);
+        options.html = iitc.util.convertTextToTableMagic('');
+      }
+      else
+        options.html = iitc.util.convertTextToTableMagic(options.text);
+    }
+
+    // merge defaults and provided options
+    let opts: ImmutableDialogOptions = $.extend({}, defaults, options);
+
+    return opts;
   }
 }

--- a/v2/core/ui/dialog.ts
+++ b/v2/core/ui/dialog.ts
@@ -49,7 +49,7 @@ namespace iitc.ui.dialog {
   function initialize(options: DialogOptions): ImmutableDialogOptions {
     // all optional properties must have a default
     let defaults: DialogOptions = {
-      class: 'ui-dialog-modal',
+      class: '',
       draggable: true,
       id: '',
       html: '',
@@ -70,6 +70,15 @@ namespace iitc.ui.dialog {
       }
       else
         options.html = iitc.util.convertTextToTableMagic(options.text);
+    }
+
+    // modal dialogs should not be draggable
+    if (options.modal) {
+      if (typeof options.class == 'undefined') {
+        options.class = '';
+      }
+      options.class = (options.class ? options.class + ' ' : '') + 'ui-dialog-modal';
+      options.draggable = false;
     }
 
     // merge defaults and provided options

--- a/v2/core/util/util.ts
+++ b/v2/core/util/util.ts
@@ -3,6 +3,37 @@
  */
 namespace iitc.util {
 
+  export function convertTextToTableMagic(text: string): string {
+    // check if it should be converted to a table
+    if(!text.match(/\t/)) return text.replace(/\n/g, '<br>');
+
+    let data: Array<Array<string>> = [];
+    let columnCount: number = 0;
+
+    // parse data
+    let rows: Array<string> = text.split('\n');
+    $.each(rows, function(i, row) {
+      data[i] = row.split('\t');
+      if(data[i].length > columnCount) columnCount = data[i].length;
+    });
+
+    // build the table
+    let table: string = '<table>';
+    $.each(data, function(i) {
+      table += '<tr>';
+      $.each(data[i], function(k, cell) {
+        let attributes: string = '';
+        if(k === 0 && data[i].length < columnCount) {
+          attributes = ' colspan="'+(columnCount - data[i].length + 1)+'"';
+        }
+        table += '<td'+attributes+'>'+cell+'</td>';
+      });
+      table += '</tr>';
+    });
+    table += '</table>';
+    return table;
+  }
+
   /**
    * Add thousand separators to a number.
    *


### PR DESCRIPTION
- Defines the public `DialogOptions` object, used for creating new dialog windows
- Defines an immutable counterpart with all members as read-only
- Merge with default options
